### PR TITLE
Add API documentation and integration examples

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,386 @@
+# Passkey Server API Documentation
+
+This document describes how to integrate with the Nuri Passkey Server from any client application (Android, iOS, Web, etc.).
+
+## Server Details
+- **Base URL**: `https://passkey.nuri.com`
+- **RP ID**: `nuri.com`
+- **Supported Origins**: `https://passkey.nuri.com`, `https://nuri.com`
+
+## Authentication Flow Overview
+
+1. **Registration**: Create a new passkey for a user
+2. **Authentication**: Sign in with an existing passkey
+3. **Data Storage**: Store encrypted data associated with the user
+
+## API Endpoints
+
+### 1. Generate Registration Options
+Get the challenge and options needed to create a new passkey.
+
+**Endpoint**: `GET /generate-registration-options`
+
+**Query Parameters**:
+- `username` (optional): Username for the account. If not provided, creates anonymous user.
+
+**Example Request**:
+```bash
+# Named user
+GET https://passkey.nuri.com/generate-registration-options?username=john_doe
+
+# Anonymous user
+GET https://passkey.nuri.com/generate-registration-options
+```
+
+**Response**:
+```json
+{
+  "challenge": "uMgkqqp2bLRJZHSqR6D4...",
+  "rp": {
+    "id": "nuri.com",
+    "name": "Nuri Passkey Server"
+  },
+  "user": {
+    "id": "base64url-encoded-user-id",
+    "name": "john_doe",
+    "displayName": "john_doe"
+  },
+  "pubKeyCredParams": [
+    { "alg": -8, "type": "public-key" },
+    { "alg": -7, "type": "public-key" },
+    { "alg": -257, "type": "public-key" }
+  ],
+  "timeout": 60000,
+  "attestation": "none",
+  "excludeCredentials": [],
+  "authenticatorSelection": {
+    "residentKey": "required",
+    "userVerification": "preferred",
+    "requireResidentKey": true
+  },
+  "extensions": { "credProps": true },
+  "challengeKey": "john_doe"  // or "anon_1234567890" for anonymous
+}
+```
+
+### 2. Verify Registration
+Submit the credential created by the authenticator for verification and storage.
+
+**Endpoint**: `POST /verify-registration`
+
+**Headers**:
+```
+Content-Type: application/json
+```
+
+**Request Body**:
+```json
+{
+  "username": "john_doe",  // or "Anonymous" for anonymous users
+  "challengeKey": "john_doe",  // from registration options response
+  "cred": {
+    "id": "base64url-encoded-credential-id",
+    "rawId": "base64url-encoded-credential-id",
+    "type": "public-key",
+    "response": {
+      "attestationObject": "base64url-encoded-attestation",
+      "clientDataJSON": "base64url-encoded-client-data",
+      "transports": ["usb", "nfc", "ble", "internal"]  // optional
+    }
+  }
+}
+```
+
+**Response (Success)**:
+```json
+{
+  "verified": true,
+  "userId": 123,
+  "username": "john_doe"
+}
+```
+
+**Response (Error)**:
+```json
+{
+  "error": "Challenge not found"
+}
+```
+
+### 3. Generate Authentication Options
+Get the challenge needed to authenticate with an existing passkey.
+
+**Endpoint**: `GET /generate-authentication-options`
+
+**Example Request**:
+```bash
+GET https://passkey.nuri.com/generate-authentication-options
+```
+
+**Response**:
+```json
+{
+  "challenge": "X2JqnWMrEgrRyFq6PRsu3JBP...",
+  "timeout": 60000,
+  "rpId": "nuri.com",
+  "userVerification": "preferred",
+  "allowCredentials": []  // Empty array allows any credential
+}
+```
+
+### 4. Verify Authentication
+Submit the signed challenge to authenticate the user.
+
+**Endpoint**: `POST /verify-authentication`
+
+**Headers**:
+```
+Content-Type: application/json
+```
+
+**Request Body**:
+```json
+{
+  "cred": {
+    "id": "base64url-encoded-credential-id",
+    "rawId": "base64url-encoded-credential-id",
+    "type": "public-key",
+    "response": {
+      "authenticatorData": "base64url-encoded-auth-data",
+      "clientDataJSON": "base64url-encoded-client-data",
+      "signature": "base64url-encoded-signature",
+      "userHandle": "base64url-encoded-user-handle"  // optional
+    }
+  }
+}
+```
+
+**Response (Success)**:
+```json
+{
+  "verified": true,
+  "userId": 123,
+  "username": "john_doe"
+}
+```
+
+**Response (Error)**:
+```json
+{
+  "error": "Authenticator not found"
+}
+```
+
+### 5. Store User Data
+Store encrypted data associated with the authenticated user.
+
+**Endpoint**: `POST /store-data`
+
+**Headers**:
+```
+Content-Type: application/json
+Authorization: Bearer <session-token>  // Received from verify-authentication
+```
+
+**Request Body**:
+```json
+{
+  "data": {
+    "encrypted": "your-encrypted-data",
+    "anyField": "any-value"
+  }
+}
+```
+
+**Response**:
+```json
+{
+  "success": true
+}
+```
+
+### 6. Get User Data
+Retrieve stored data for the authenticated user.
+
+**Endpoint**: `GET /get-data`
+
+**Headers**:
+```
+Authorization: Bearer <session-token>  // Received from verify-authentication
+```
+
+**Response**:
+```json
+{
+  "data": {
+    "encrypted": "your-encrypted-data",
+    "anyField": "any-value"
+  },
+  "lastUpdated": "2025-07-31T10:30:00Z"
+}
+```
+
+## Android Integration Example
+
+### 1. Add Dependencies (build.gradle)
+```gradle
+dependencies {
+    implementation 'androidx.credentials:credentials:1.3.0'
+    implementation 'androidx.credentials:credentials-play-services-auth:1.3.0'
+    implementation 'com.google.android.gms:play-services-fido:21.1.0'
+}
+```
+
+### 2. Registration Flow
+```kotlin
+class PasskeyManager(private val context: Context) {
+    private val credentialManager = CredentialManager.create(context)
+    
+    suspend fun registerPasskey(username: String? = null) {
+        // Step 1: Get registration options from server
+        val optionsResponse = api.getRegistrationOptions(username)
+        
+        // Step 2: Create credential
+        val createRequest = CreatePublicKeyCredentialRequest(
+            requestJson = buildRegistrationJson(optionsResponse)
+        )
+        
+        try {
+            val result = credentialManager.createCredential(
+                request = createRequest,
+                context = context
+            )
+            
+            // Step 3: Verify with server
+            val credential = result as CreatePublicKeyCredentialResponse
+            api.verifyRegistration(
+                username = username ?: "Anonymous",
+                challengeKey = optionsResponse.challengeKey,
+                credential = parseCredentialResponse(credential)
+            )
+        } catch (e: Exception) {
+            // Handle errors
+        }
+    }
+    
+    private fun buildRegistrationJson(options: RegistrationOptions): String {
+        return JSONObject().apply {
+            put("challenge", options.challenge)
+            put("rp", JSONObject().apply {
+                put("name", options.rp.name)
+                put("id", options.rp.id)
+            })
+            put("user", JSONObject().apply {
+                put("id", options.user.id)
+                put("name", options.user.name)
+                put("displayName", options.user.displayName)
+            })
+            put("pubKeyCredParams", JSONArray().apply {
+                options.pubKeyCredParams.forEach { param ->
+                    put(JSONObject().apply {
+                        put("type", param.type)
+                        put("alg", param.alg)
+                    })
+                }
+            })
+            put("timeout", options.timeout)
+            put("attestation", options.attestation)
+            put("authenticatorSelection", JSONObject().apply {
+                put("residentKey", options.authenticatorSelection.residentKey)
+                put("userVerification", options.authenticatorSelection.userVerification)
+            })
+        }.toString()
+    }
+}
+```
+
+### 3. Authentication Flow
+```kotlin
+suspend fun authenticateWithPasskey() {
+    // Step 1: Get authentication options
+    val optionsResponse = api.getAuthenticationOptions()
+    
+    // Step 2: Get credential
+    val getRequest = GetPublicKeyCredentialOption(
+        requestJson = buildAuthenticationJson(optionsResponse)
+    )
+    
+    val getCredRequest = GetCredentialRequest(
+        listOf(getRequest)
+    )
+    
+    try {
+        val result = credentialManager.getCredential(
+            request = getCredRequest,
+            context = context
+        )
+        
+        // Step 3: Verify with server
+        val credential = result.credential as GetPublicKeyCredentialResponse
+        val authResult = api.verifyAuthentication(
+            credential = parseAuthCredentialResponse(credential)
+        )
+        
+        // Save session token
+        sessionToken = authResult.sessionToken
+    } catch (e: Exception) {
+        // Handle errors
+    }
+}
+```
+
+## Important Notes
+
+### 1. Base64URL Encoding
+All binary data (credential IDs, challenges, etc.) must be encoded using Base64URL format:
+- Replace `+` with `-`
+- Replace `/` with `_`
+- Remove padding `=`
+
+### 2. User Verification
+The server accepts both:
+- **Platform authenticators** (fingerprint, Face ID): User verification performed
+- **Hardware security keys** (YubiKey): User verification optional (touch only)
+
+### 3. Anonymous Users
+- Don't provide a username during registration
+- Server creates anonymous user with ID like `anon_123456`
+- Credential ID becomes the user identifier
+
+### 4. Error Handling
+Common errors:
+- `400 Bad Request`: Invalid request format
+- `404 Not Found`: Challenge expired or credential not found
+- `500 Internal Server Error`: Server issue
+
+### 5. Session Management
+After successful authentication:
+- Server returns a session token
+- Include in Authorization header for subsequent requests
+- Token expires after inactivity
+
+## Testing
+
+### Test Endpoints
+The server includes a web dashboard for testing:
+- Registration: `https://passkey.nuri.com/dashboard.html`
+- Click "Register Platform Authenticator" or "Register Security Key"
+
+### Debug Mode
+For debugging, the server logs:
+- Credential IDs being searched
+- Available credentials in database
+- Encoding formats for comparison
+
+## Security Considerations
+
+1. **HTTPS Required**: WebAuthn only works over secure connections
+2. **Origin Validation**: Server validates requests come from allowed origins
+3. **Challenge Expiration**: Challenges expire after 60 seconds
+4. **Replay Protection**: Each challenge can only be used once
+
+## Support
+
+For issues or questions:
+- GitHub: https://github.com/nuri-com/passkey-server
+- Server logs: Check PM2 logs for detailed error messages

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -1,0 +1,86 @@
+# Passkey Server Quick Reference
+
+## Base URL
+```
+https://passkey.nuri.com
+```
+
+## Registration Flow
+```
+1. GET  /generate-registration-options?username=john_doe
+2. Create credential with platform authenticator
+3. POST /verify-registration
+   Body: {
+     "username": "john_doe",
+     "challengeKey": "from_step_1",
+     "cred": { /* credential response */ }
+   }
+```
+
+## Authentication Flow
+```
+1. GET  /generate-authentication-options
+2. Get credential from platform authenticator
+3. POST /verify-authentication
+   Body: {
+     "cred": { /* credential response */ }
+   }
+```
+
+## Key Points
+- All binary data must be Base64URL encoded
+- RP ID is `nuri.com` for all platforms
+- User verification is `preferred` (not required)
+- Anonymous users supported (omit username)
+- Challenges expire after 60 seconds
+
+## Platform-Specific Notes
+
+### iOS
+- Use `ASAuthorizationController`
+- For YubiKey: set `userVerificationPreference = .discouraged`
+
+### Android
+- Use `CredentialManager` API
+- Requires Android 14+ for best support
+- Add Play Services FIDO dependency
+
+### Web
+- Use `navigator.credentials` API
+- Must be served over HTTPS
+- Check browser compatibility
+
+## Response Formats
+
+### Success
+```json
+{
+  "verified": true,
+  "userId": 123,
+  "username": "john_doe"
+}
+```
+
+### Error
+```json
+{
+  "error": "Error message here"
+}
+```
+
+## Common Issues
+
+1. **Authenticator not found**
+   - Credential wasn't registered on this server
+   - Client using wrong credential ID
+
+2. **Challenge not found**
+   - Challenge expired (>60 seconds)
+   - Wrong challengeKey sent
+
+3. **Origin not allowed**
+   - Must use https://nuri.com or https://passkey.nuri.com
+   - Check CORS headers
+
+## Testing
+Dashboard available at: https://passkey.nuri.com/dashboard.html

--- a/examples/AndroidIntegration.kt
+++ b/examples/AndroidIntegration.kt
@@ -1,0 +1,276 @@
+// Android Passkey Integration Example
+// Requires Android 14+ (API 34+) for best support
+
+package com.example.passkeyintegration
+
+import android.content.Context
+import androidx.credentials.*
+import androidx.credentials.exceptions.*
+import com.google.android.gms.fido.Fido
+import com.google.android.gms.fido.fido2.api.common.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.Base64
+
+class PasskeyServerIntegration(private val context: Context) {
+    private val credentialManager = CredentialManager.create(context)
+    private val serverUrl = "https://passkey.nuri.com"
+    private var sessionToken: String? = null
+    
+    // REGISTRATION FLOW
+    suspend fun registerNewPasskey(username: String? = null): Result<String> {
+        return try {
+            // Step 1: Get registration options from server
+            val optionsUrl = if (username != null) {
+                "$serverUrl/generate-registration-options?username=$username"
+            } else {
+                "$serverUrl/generate-registration-options"
+            }
+            
+            val optionsResponse = httpGet(optionsUrl)
+            val options = JSONObject(optionsResponse)
+            
+            // Step 2: Create the credential request JSON
+            val createCredentialRequest = JSONObject().apply {
+                put("rp", options.getJSONObject("rp"))
+                put("user", options.getJSONObject("user"))
+                put("challenge", options.getString("challenge"))
+                put("pubKeyCredParams", options.getJSONArray("pubKeyCredParams"))
+                put("timeout", options.getLong("timeout"))
+                put("attestation", options.getString("attestation"))
+                put("authenticatorSelection", options.getJSONObject("authenticatorSelection"))
+            }
+            
+            // Step 3: Create passkey using Credential Manager
+            val createRequest = CreatePublicKeyCredentialRequest(
+                requestJson = createCredentialRequest.toString()
+            )
+            
+            val result = credentialManager.createCredential(
+                request = createRequest,
+                context = context
+            ) as CreatePublicKeyCredentialResponse
+            
+            // Step 4: Parse the response
+            val responseJson = JSONObject(result.registrationResponseJson)
+            
+            // Step 5: Verify with server
+            val verifyRequest = JSONObject().apply {
+                put("username", username ?: "Anonymous")
+                put("challengeKey", options.getString("challengeKey"))
+                put("cred", JSONObject().apply {
+                    put("id", responseJson.getString("id"))
+                    put("rawId", responseJson.getString("rawId"))
+                    put("type", responseJson.getString("type"))
+                    put("response", responseJson.getJSONObject("response"))
+                })
+            }
+            
+            val verifyResponse = httpPost(
+                "$serverUrl/verify-registration",
+                verifyRequest.toString()
+            )
+            
+            val verifyResult = JSONObject(verifyResponse)
+            if (verifyResult.getBoolean("verified")) {
+                Result.success("Registration successful for user: ${verifyResult.getString("username")}")
+            } else {
+                Result.failure(Exception("Registration verification failed"))
+            }
+            
+        } catch (e: CreateCredentialCancellationException) {
+            Result.failure(Exception("User cancelled registration"))
+        } catch (e: CreateCredentialException) {
+            Result.failure(Exception("Registration failed: ${e.message}"))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+    
+    // AUTHENTICATION FLOW
+    suspend fun authenticateWithPasskey(): Result<String> {
+        return try {
+            // Step 1: Get authentication options
+            val optionsResponse = httpGet("$serverUrl/generate-authentication-options")
+            val options = JSONObject(optionsResponse)
+            
+            // Step 2: Create authentication request
+            val authRequest = JSONObject().apply {
+                put("challenge", options.getString("challenge"))
+                put("timeout", options.getLong("timeout"))
+                put("rpId", options.getString("rpId"))
+                put("userVerification", options.getString("userVerification"))
+                if (options.has("allowCredentials")) {
+                    put("allowCredentials", options.getJSONArray("allowCredentials"))
+                }
+            }
+            
+            // Step 3: Get credential
+            val getCredentialRequest = GetPublicKeyCredentialOption(
+                requestJson = authRequest.toString()
+            )
+            
+            val getRequest = GetCredentialRequest(
+                listOf(getCredentialRequest)
+            )
+            
+            val result = credentialManager.getCredential(
+                request = getRequest,
+                context = context
+            )
+            
+            val credential = result.credential as GetPublicKeyCredentialResponse
+            val responseJson = JSONObject(credential.authenticationResponseJson)
+            
+            // Step 4: Verify with server
+            val verifyRequest = JSONObject().apply {
+                put("cred", responseJson)
+            }
+            
+            val verifyResponse = httpPost(
+                "$serverUrl/verify-authentication",
+                verifyRequest.toString()
+            )
+            
+            val authResult = JSONObject(verifyResponse)
+            if (authResult.getBoolean("verified")) {
+                // Store session token if provided
+                if (authResult.has("sessionToken")) {
+                    sessionToken = authResult.getString("sessionToken")
+                }
+                Result.success("Authenticated as: ${authResult.getString("username")}")
+            } else {
+                Result.failure(Exception("Authentication failed"))
+            }
+            
+        } catch (e: GetCredentialCancellationException) {
+            Result.failure(Exception("User cancelled authentication"))
+        } catch (e: NoCredentialException) {
+            Result.failure(Exception("No passkeys found"))
+        } catch (e: GetCredentialException) {
+            Result.failure(Exception("Authentication failed: ${e.message}"))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+    
+    // STORE ENCRYPTED DATA
+    suspend fun storeUserData(data: Map<String, Any>): Result<Boolean> {
+        return try {
+            val token = sessionToken ?: return Result.failure(Exception("Not authenticated"))
+            
+            val request = JSONObject().apply {
+                put("data", JSONObject(data))
+            }
+            
+            val response = httpPost(
+                "$serverUrl/store-data",
+                request.toString(),
+                mapOf("Authorization" to "Bearer $token")
+            )
+            
+            val result = JSONObject(response)
+            Result.success(result.getBoolean("success"))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+    
+    // RETRIEVE USER DATA
+    suspend fun getUserData(): Result<Map<String, Any>> {
+        return try {
+            val token = sessionToken ?: return Result.failure(Exception("Not authenticated"))
+            
+            val response = httpGet(
+                "$serverUrl/get-data",
+                mapOf("Authorization" to "Bearer $token")
+            )
+            
+            val result = JSONObject(response)
+            val data = result.getJSONObject("data")
+            
+            // Convert JSONObject to Map
+            val dataMap = mutableMapOf<String, Any>()
+            data.keys().forEach { key ->
+                dataMap[key] = data.get(key)
+            }
+            
+            Result.success(dataMap)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+    
+    // Helper function for HTTP GET requests
+    private suspend fun httpGet(
+        url: String,
+        headers: Map<String, String> = emptyMap()
+    ): String = withContext(Dispatchers.IO) {
+        val connection = java.net.URL(url).openConnection() as java.net.HttpURLConnection
+        connection.requestMethod = "GET"
+        headers.forEach { (key, value) ->
+            connection.setRequestProperty(key, value)
+        }
+        connection.inputStream.bufferedReader().use { it.readText() }
+    }
+    
+    // Helper function for HTTP POST requests
+    private suspend fun httpPost(
+        url: String,
+        body: String,
+        headers: Map<String, String> = emptyMap()
+    ): String = withContext(Dispatchers.IO) {
+        val connection = java.net.URL(url).openConnection() as java.net.HttpURLConnection
+        connection.requestMethod = "POST"
+        connection.setRequestProperty("Content-Type", "application/json")
+        headers.forEach { (key, value) ->
+            connection.setRequestProperty(key, value)
+        }
+        connection.doOutput = true
+        
+        connection.outputStream.use { os ->
+            os.write(body.toByteArray())
+        }
+        
+        connection.inputStream.bufferedReader().use { it.readText() }
+    }
+}
+
+// Usage Example in an Activity or Fragment
+class MainActivity : AppCompatActivity() {
+    private lateinit var passkeyIntegration: PasskeyServerIntegration
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        passkeyIntegration = PasskeyServerIntegration(this)
+    }
+    
+    fun onRegisterClick() {
+        lifecycleScope.launch {
+            when (val result = passkeyIntegration.registerNewPasskey("test_user")) {
+                is Result.Success -> {
+                    Toast.makeText(this@MainActivity, result.value, Toast.LENGTH_SHORT).show()
+                }
+                is Result.Failure -> {
+                    Toast.makeText(this@MainActivity, "Registration failed: ${result.error.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+    
+    fun onAuthenticateClick() {
+        lifecycleScope.launch {
+            when (val result = passkeyIntegration.authenticateWithPasskey()) {
+                is Result.Success -> {
+                    Toast.makeText(this@MainActivity, result.value, Toast.LENGTH_SHORT).show()
+                    // Now you can store/retrieve user data
+                }
+                is Result.Failure -> {
+                    Toast.makeText(this@MainActivity, "Authentication failed: ${result.error.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for developers who want to integrate with the Nuri Passkey Server.

## New Files Added

### 📚 API_DOCUMENTATION.md
Complete API reference including:
- All endpoints with request/response formats
- Authentication and registration flows
- Data storage endpoints
- Security considerations
- Troubleshooting guide

### 🚀 QUICK_REFERENCE.md
One-page quick reference with:
- Essential endpoints
- Common integration patterns
- Platform-specific notes
- Error handling tips

### 📱 examples/AndroidIntegration.kt
Full Android example featuring:
- Complete Kotlin implementation
- Credential Manager API usage
- Registration and authentication flows
- Proper error handling
- Session management

## Integration Flow

The documentation covers the standard WebAuthn flow:

1. **Registration**
   ```
   GET  /generate-registration-options?username=john_doe
   POST /verify-registration
   ```

2. **Authentication**
   ```
   GET  /generate-authentication-options
   POST /verify-authentication
   ```

3. **Data Storage** (authenticated users)
   ```
   POST /store-data
   GET  /get-data
   ```

## Key Features Documented

- ✅ Base64URL encoding requirements
- ✅ Anonymous user support
- ✅ Hardware security key integration
- ✅ Platform-specific implementation notes
- ✅ Common errors and solutions
- ✅ Security best practices

## Who This Helps

- Android developers integrating passkey authentication
- iOS developers building passkey support
- Web developers implementing WebAuthn
- Anyone building applications that need secure, passwordless authentication

## Testing

All API endpoints documented here are currently live on `https://passkey.nuri.com` and can be tested using the provided examples.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>